### PR TITLE
Add must_use attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,12 +100,14 @@ mod details {
     }
 
     impl<F: FloatCore> Default for Accumulator<F> {
+        #[must_use]
         fn default() -> Self {
             Self::new()
         }
     }
 
     impl<F: FloatCore> Accumulator<F> {
+        #[must_use]
         pub fn new() -> Self {
             Self {
                 x_mean: F::zero(),


### PR DESCRIPTION
Add the `#[must_use]` attribute for public functions returning something.

More info: https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate