### PR TITLE
Add an optional `std` feature that implements `std::error::Error`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ num-traits = "0.2.4"
 [dependencies.displaydoc]
 version = "0.1.5"
 default-features = false  # Do not pull in `std` feature.
+
+[features]
+std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ extern crate num_traits;
 
 use num_traits::float::FloatCore;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "std"))]
 #[macro_use]
 extern crate std;
 
@@ -62,6 +62,9 @@ pub enum Error {
     /// Can't compute linear regression of zero elements
     NoElements,
 }
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
 
 /// Single-pass simple linear regression.
 ///


### PR DESCRIPTION
The `std::error::Error` trait is required for some error handling frameworks. This pull request adds an optional `std` feature that implements it for the `Error` enum.

The new `std` feature is also useful if `linreg` is compiled together with other dependencies that also use the `displaydoc` crate, but with its default feature set. Since Cargo unifies all dependency features, `displaydoc` is compiled with its `std` feature enabled, even though `linreg` sets `default-features = false` for it. This results in a compilation failure if the `std` library is not included in `linreg`.