### PR TITLE
Update displaydoc to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ version = "0.2.0"
 num-traits = "0.2.4"
 
 [dependencies.displaydoc]
-version = "0.1.5"
+version = "0.2"
 default-features = false  # Do not pull in `std` feature.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,9 +53,8 @@ use displaydoc::Display;
 pub enum Error {
     /// The slope is too steep to represent, approaching infinity.
     TooSteep,
-    /// Failed to calculate mean.
-    ///
-    /// This means the input was empty or had too many elements.
+    /** Failed to calculate mean.
+        This means the input was empty or had too many elements. */
     Mean,
     /// Lengths of the inputs are different.
     InputLenDif,


### PR DESCRIPTION
This required changing the multiline comment to use `/**` per https://github.com/yaahc/displaydoc#details