### PR TITLE
Do not pull in default features from num-traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,9 @@ readme = "README.md"
 repository = "https://github.com/49nord/linreg-rs.git"
 version = "0.2.0"
 
-[dependencies]
-num-traits = "0.2.4"
+[dependencies.num-traits]
+version = "0.2.15"
+default-features = false  # Do not pull in `std` feature.
 
 [dependencies.displaydoc]
 version = "0.1.5"


### PR DESCRIPTION
This was keeping me from compiling it for `#[no_std]` environments. We don't need the `std` features from `num-traits`.